### PR TITLE
Fixes AB#462 BUG462: Can't open account page in EE

### DIFF
--- a/src/Feature/Account/client/ChangePassword/Component.tsx
+++ b/src/Feature/Account/client/ChangePassword/Component.tsx
@@ -29,7 +29,9 @@ export default class ChangePasswordComponent extends Jss.SafePureComponent<
   ChangePasswordOwnState
 > {
   public componentDidMount() {
-    this.props.VerifyCommerceUser();
+    if (!this.props.sitecoreContext.pageEditing) {
+      this.props.VerifyCommerceUser();
+    }
   }
 
   protected safeRender() {

--- a/src/Feature/Account/client/ChangePassword/index.ts
+++ b/src/Feature/Account/client/ChangePassword/index.ts
@@ -12,9 +12,12 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-import { withExperienceEditorChromes } from '@sitecore-jss/sitecore-jss-react';
+import { renderingWithContext } from 'Foundation/ReactJss/client';
 import { connect } from 'react-redux';
+import { compose } from 'recompose';
 import { bindActionCreators, Dispatch } from 'redux';
+
+import { withExperienceEditorChromes } from '@sitecore-jss/sitecore-jss-react';
 
 import * as Account from 'Feature/Account/client/Integration/Account';
 
@@ -42,6 +45,6 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
 const connectedToStore = connect<ChangePasswordStateProps, ChangePasswordDispatchProps, ChangePasswordOwnProps>(
   mapStateToProps,
   mapDispatchToProps
-)(Component);
+);
 
-export const ChangePassword = withExperienceEditorChromes(connectedToStore);
+export const ChangePassword = compose(withExperienceEditorChromes, connectedToStore, renderingWithContext)(Component) ;

--- a/src/Feature/Account/client/ChangePassword/index.ts
+++ b/src/Feature/Account/client/ChangePassword/index.ts
@@ -17,8 +17,6 @@ import { connect } from 'react-redux';
 import { compose } from 'recompose';
 import { bindActionCreators, Dispatch } from 'redux';
 
-import { withExperienceEditorChromes } from '@sitecore-jss/sitecore-jss-react';
-
 import * as Account from 'Feature/Account/client/Integration/Account';
 
 import Component from './Component';
@@ -47,4 +45,4 @@ const connectedToStore = connect<ChangePasswordStateProps, ChangePasswordDispatc
   mapDispatchToProps
 );
 
-export const ChangePassword = compose(withExperienceEditorChromes, connectedToStore, renderingWithContext)(Component) ;
+export const ChangePassword = compose(connectedToStore, renderingWithContext)(Component) ;

--- a/src/Feature/Account/client/ChangePassword/models.ts
+++ b/src/Feature/Account/client/ChangePassword/models.ts
@@ -16,7 +16,7 @@ import * as Jss from 'Foundation/ReactJss/client';
 
 import * as Account from 'Feature/Account/client/Integration/Account';
 
-export interface ChangePasswordOwnProps extends Jss.Rendering<Jss.BaseDataSourceItem> {}
+export interface ChangePasswordOwnProps extends Jss.RenderingWithContext<Jss.BaseDataSourceItem> {}
 
 export interface ChangePasswordStateProps {
   changePasswordState: Account.ChangePasswordState;


### PR DESCRIPTION
### Description: 
Add the condition where do not need to verify user when the account page is being opened in EE

### Reasons:
When trying to open the Account page in EE the Home page is opened instead