### PR TITLE
AB#454 US454 Save new address in account from shippingInfo

### DIFF
--- a/src/Feature/Checkout/client/Shipping/Component.tsx
+++ b/src/Feature/Checkout/client/Shipping/Component.tsx
@@ -31,7 +31,9 @@ export default class ShippingComponent extends Jss.SafePureComponent<ShippingPro
     super(props);
     const { commerceUser } = this.props;
     const selectedAddressOption = commerceUser && commerceUser.customerId ? ADDRESS_TYPE.SAVED : ADDRESS_TYPE.NEW;
+    const disableSaveToMyAccount = !(commerceUser && commerceUser.customerId);
     this.state = {
+      disableSaveToMyAccount,
       selectedAddressOption,
     };
   }
@@ -203,7 +205,7 @@ export default class ShippingComponent extends Jss.SafePureComponent<ShippingPro
               </div>
               {this.state.selectedAddressOption === ADDRESS_TYPE.NEW && (
                 <div className="col-sm-6">
-                  <Input type="checkbox" name={FIELDS.SAVE_TO_MY_ACCOUNT} id="save-to-account" />
+                  <Input type="checkbox" name={FIELDS.SAVE_TO_MY_ACCOUNT} id="save-to-account"  disabled={this.state.disableSaveToMyAccount} />
                   <label htmlFor="save-to-account">
                     <Text field={{ value: 'Save this address to' }} tag="span" />{' '}
                     <Text field={{ value: 'My Account.' }} tag="strong" />
@@ -265,7 +267,7 @@ export default class ShippingComponent extends Jss.SafePureComponent<ShippingPro
 
   // tslint:disable-next-line:cognitive-complexity
   private handleSaveAndContinueClick(formValues: FormValues) {
-    const { SubmitStep, shippingInfo } = this.props;
+    const { SubmitStep, shippingInfo, AddAddressToAccount } = this.props;
 
     const selectedShippingMethodId = formValues[FIELDS.SELECTED_SHIPPING_METHOD];
     const shippingMethod = shippingInfo.data.shippingMethods.find((a) => a.externalId === selectedShippingMethodId);
@@ -278,6 +280,10 @@ export default class ShippingComponent extends Jss.SafePureComponent<ShippingPro
       useForBillingAddress,
     };
     const address = this.getShippingAddress(formValues);
+
+    if (saveToMyAccount) {
+      AddAddressToAccount(address);
+    }
 
     if (address && shippingMethod) {
       SubmitStep({

--- a/src/Feature/Checkout/client/Shipping/index.ts
+++ b/src/Feature/Checkout/client/Shipping/index.ts
@@ -12,6 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+import * as Account from 'Feature/Account/client/Integration/Account';
+
 import { connect } from 'react-redux';
 import { compose } from 'recompose';
 import { bindActionCreators } from 'redux';
@@ -42,8 +44,9 @@ const mapStateToProps = (state: AppState): ShippingStateProps => {
 const mapDispatchToProps = (dispatch: any) => {
   return bindActionCreators(
     {
+      AddAddressToAccount: Account.AddAddress,
       InitStep: Checkout.InitStep,
-      SubmitStep: Checkout.SubmitStep,
+      SubmitStep: Checkout.SubmitStep
     },
     dispatch
   );

--- a/src/Feature/Checkout/client/Shipping/models.ts
+++ b/src/Feature/Checkout/client/Shipping/models.ts
@@ -32,11 +32,13 @@ export interface ShippingStateProps {
 export interface ShippingDispatchProps {
   InitStep: (step: Checkout.CheckoutStepType) => void;
   SubmitStep: (stepValues: Checkout.StepValues) => void;
+  AddAddressToAccount: (address: Commerce.Address) => void;
 }
 
 export interface ShippingProps extends ShippingOwnProps, ShippingStateProps, ShippingDispatchProps {}
 
 export interface ShippingState extends Jss.SafePureComponentState {
   selectedAddressOption: string;
+  disableSaveToMyAccount: boolean;
 }
 export interface AppState extends Checkout.GlobalCheckoutState, Checkout.AppState {}


### PR DESCRIPTION
**Descripion:**
Add dependency from Account feature to Shipping feature to be able to link a new address to an account.
Add a condition into SaveAndContinueClick handler for checking whether the checkbox is checked 'Save address to my account' and the call AddAddressToAccount

**Motivation**
Save a new address if a customer selects 'Save Address to My Account' on the first step of the checkout workflow.Add dependency from Account feature to Shipping feature to be able to link a new address to an account.
Add a condition into SaveAndContinueClick handler for checking whether the checkbox is checked 'Save address to my account' and the call AddAddressToAccount